### PR TITLE
GitHub Actions workflow to deploy to Curvenote

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+# This file was created automatically with `myst init --gh-curvenote` 🪄 💚
+
+name: Curvenote Deploy
+on:
+  push:
+    # Runs on pushes targeting the default branch
+    branches: [main]
+permissions:
+  # Sets permissions of the GITHUB_TOKEN to allow read of private repos
+  contents: read
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy 🚀
+        uses: curvenote/action-myst-publish@v1
+        env:
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE_TOKEN }}

--- a/myst.yml
+++ b/myst.yml
@@ -15,3 +15,5 @@ project:
     - file: 'section_example.md'
 site:
   template: book-theme
+  domains:
+    - ezoni.curve.space


### PR DESCRIPTION
@jlvay @DavidSagan 

I followed the instructions found in the MyST docs to set up an example of deployment to Curvenote (FYI, @jlvay asked me to look into this after this morning's meeting).

So far I have opened a personal Curvenote account, so the domain site reads `ezoni.curve.space`. From personal accounts it is possible to create team accounts, but after creating a tentative team account for the accelerator lattice standard it looked like team accounts might not be free (after a free 14-day trial). Read the Docs might be more flexible when it comes to custom domains (we don't want `ezoni.curve.space` to be the final choice) - to be investigated further.

These are the steps that I was prompted to follow after running `myst init --gh-curvenote` locally (which created the GitHub Actions workflow file automatically):
```console
1. Ensure you have a domain set in your site configuration

    site:
      domains:
        - username.curve.space

2. Create a new Curvenote API token

    https://curvenote.com/profile?settings=true&tab=profile-api

3. Navigate to your GitHub settings for action secrets

    https://github.com/campa-consortium/lattice-standard/settings/secrets/actions

4. Add a new repository secret

    Name: CURVENOTE_TOKEN
    Secret: Your Curvenote API Token

5. Push these changes (and/or merge to main)
6. Look for a new action to start

    https://github.com/campa-consortium/lattice-standard/actions

7. Once the action completes, your site should be deployed
```

I think I took care of steps 1-4. Step 5 is to merge this PR into the `main` branch. After that in theory we could check if we see a site deployed at `ezoni.curve.space`. All of this should be "undoable", this should be only a test (although it is necessary to merge into `main` in order to test).