### PR TITLE
Comment out domain from MyST configuration

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -15,5 +15,5 @@ project:
     - file: 'section_example.md'
 site:
   template: book-theme
-  domains:
-    - ezoni.curve.space
+  #domains:
+  #  - <username>-<project>.curve.space


### PR DESCRIPTION
Temporarily comment out public domain from the MyST YAML configuration file, until a decision is made. 

This is to avoid pushing content to that domain, which cannot be easily cleared without contacting Curvenote support. 

Local deployment remains the same.