### PR TITLE
CI: do not run deployment until domain is fixed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: 0 # TODO remove this once deployment domain is finalized
     steps:
       - name: Deploy 🚀
         uses: curvenote/action-myst-publish@v1


### PR DESCRIPTION
The GitHub Actions workflow "Curvenote Deploy" is currently failing (see, for example, https://github.com/campa-consortium/lattice-standard/actions/runs/12399690861/job/34615166678) because we removed the domain from the `myst.yml` file, since we have not yet finalized the decision on which domain to use.

This PR disables that workflow temporarily, until the deployment strategy is finalized.